### PR TITLE
issue #133 : Add species_list.data_resource_uid index

### DIFF
--- a/grails-app/domain/au/org/ala/specieslist/SpeciesList.groovy
+++ b/grails-app/domain/au/org/ala/specieslist/SpeciesList.groovy
@@ -57,6 +57,7 @@ class SpeciesList {
     }
 
     static mapping = {
+        dataResourceUid index: 'idx_data_resource_uid'
         items cascade: "all-delete-orphan"
         listType index: 'idx_listtype'
         username index: 'idx_username'


### PR DESCRIPTION
Adds an index on `species_list.data_resource_uid`, based on the mysql slow query log identifying slow queries that are using table scans rather than indexes.

Untested, copy and paste from the equivalent code for the other two tables that already have indexes on `data_resource_uid`:

https://github.com/AtlasOfLivingAustralia/specieslist-webapp/blob/4906d92ceaf1bf9b5089572a5c7a271fcbfc5c75/grails-app/domain/au/org/ala/specieslist/SpeciesListItem.groovy#L54

Not sure why it is duplicated everywhere, and there may be another performance issue to address for that duplication, but this table is scanned in some cases.