### PR TITLE
issue #213 adding missing user id header param on saveList specs

### DIFF
--- a/grails-app/controllers/au/org/ala/specieslist/WebServiceController.groovy
+++ b/grails-app/controllers/au/org/ala/specieslist/WebServiceController.groovy
@@ -681,7 +681,8 @@ class WebServiceController {
                 description = "The data resource id to identify the new list",
                 schema = @Schema(implementation = String),
                 required = true),
-            @Parameter(name = "Authorization", in = HEADER, schema = @Schema(implementation = String), required = true)
+            @Parameter(name = "Authorization", in = HEADER, schema = @Schema(implementation = String), required = true),
+            @Parameter(name = "X-ALA-userId",  description="The user id to save the list against", in = HEADER, schema = @Schema(implementation = String), required = true)
         ],
         responses = [
             @ApiResponse(


### PR DESCRIPTION
Addition to species list post api specs to allow  the passing of user id in the header via api gateway