### PR TITLE
Bug/issue 225

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ branches:
   - master
   - develop
   - feature/oidcIntegration
+  - bug/issue-225
 
 before_install:
   - rm -fr $HOME/.gradle/caches

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -244,3 +244,5 @@ orderColumns: 'order,ordo'
 familyColumns: 'family,familia'
 genusColumns: 'genus,genericEpithet,generic epithet'
 rankColumns: 'taxonrank,rank,taxon rank,taxonomicrank,taxonomic rank,linnaean rank'
+#determnines whether a  list owner's email is visible on list info panel.
+ownerVisibleToEditor: false

--- a/grails-app/controllers/au/org/ala/specieslist/WebServiceController.groovy
+++ b/grails-app/controllers/au/org/ala/specieslist/WebServiceController.groovy
@@ -676,7 +676,6 @@ class WebServiceController {
                 description = "The data resource id to identify an existing list",
                 schema = @Schema(implementation = String),
                 required = true),
-            @Parameter(name = "Authorization", in = HEADER, schema = @Schema(implementation = String), required = true),
             @Parameter(name = "X-ALA-userId",  description="The user id to save the list against", in = HEADER, schema = @Schema(implementation = String), required = true)
         ],
         responses = [

--- a/grails-app/views/speciesListItem/list.gsp
+++ b/grails-app/views/speciesListItem/list.gsp
@@ -22,6 +22,7 @@
 <g:set var="userCanEditData" value="${
             (speciesList.username == request.remoteUser || request.isUserInRole("ROLE_ADMIN") || userId in speciesList.editors)
 }"/>
+<g:set var="ownerVisibleToEditor" value="${grailsApplication.config.ownerVisibleToEditor.toBoolean() ? (userId in speciesList.editors) : false}"/>
 <html>
 <head>
     <meta name="layout" content="${grailsApplication.config.skin.layout}"/>
@@ -457,8 +458,10 @@
         <dl class="dl-horizontal" id="show-meta-dl">
             <dt>${message(code: 'speciesList.listName.label', default: 'List name')}</dt>
             <dd>${speciesList.listName ?: '&nbsp;'}</dd>
-            <dt>${message(code: 'speciesList.username.label', default: 'Owner')}</dt>
-            <dd>${speciesList.fullName ?: speciesList.username ?: '&nbsp;'}</dd>
+            <g:if test="${userCanEditPermissions || ownerVisibleToEditor}">
+                <dt>${message(code: 'speciesList.username.label', default: 'Owner')}</dt>
+                    <dd>${speciesList.fullName ?: speciesList.username}</dd>
+            </g:if>
             <dt>${message(code: 'speciesList.listType.label', default: 'List type')}</dt>
             <dd>${speciesList.listType?(message(code:speciesList.listType.i18nValue, default:speciesList.listType.displayValue)):''}</dd>
             <!--dd>${speciesList.listType?.displayValue}</dd-->
@@ -512,7 +515,7 @@
                     <dd>${speciesList.sdsType}</dd>
                 </g:if>
             </g:if>
-            <g:if test="${speciesList.editors}">
+            <g:if test="${speciesList.editors && userCanEditPermissions}">
                 <dt>${message(code: 'speciesList.editors.label', default: 'List editors')}</dt>
                 <dd>${speciesList.editors.collect { sl.getFullNameForUserId(userId: it) }?.join(", ")}</dd>
             </g:if>
@@ -534,18 +537,18 @@
                         </div>
                     </div>
 
-                    <div class="form-group">
-                        <label class="control-label col-md-2"
-                               for="owner">${message(code: 'speciesList.username.label', default: 'Owner')}</label>
+%{--                    <div class="form-group">--}%
+%{--                        <label class="control-label col-md-2"--}%
+%{--                               for="owner">${message(code: 'speciesList.username.label', default: 'Owner')}</label>--}%
 
-                        <div class="col-md-10">
-                            <select name="owner" id="owner" class="form-control full-width">
-                                <g:each in="${users}" var="userId"><option
-                                        value="${userId}" ${(speciesList.username == userId) ? 'selected="selected"' : ''}><sl:getFullNameForUserId
-                                            userId="${userId}"/></option></g:each>
-                            </select>
-                        </div>
-                    </div>
+%{--                        <div class="col-md-10">--}%
+%{--                            <select name="owner" id="owner" class="form-control full-width">--}%
+%{--                                <g:each in="${users}" var="userId"><option--}%
+%{--                                        value="${userId}" ${(speciesList.username == userId) ? 'selected="selected"' : ''}><sl:getFullNameForUserId--}%
+%{--                                            userId="${userId}"/></option></g:each>--}%
+%{--                            </select>--}%
+%{--                        </div>--}%
+%{--                    </div>--}%
 
                     <div class="form-group">
                         <label class="control-label col-md-2"


### PR DESCRIPTION
 - Restricted owner email visibility on list info to owner, admin and editor (if configured).
 - (As discussed with @sat01a ), Removed ability to re-assign ownership of list (by a list owner and admin) to prevent occasional long load times caused by 
userdetails lookup for all users in the species list datbase. (To be refactored with a user search input instead of dropdown at a later stage if the feature is requested to be re-enabled by users)