### PR TITLE
Allow strict name matching of lists

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     compile "org.nibor.autolink:autolink:0.5.0"
     compile "com.opencsv:opencsv:3.7"
 
-    runtime 'org.cache2k:cache2k-jcache:1.2.0.Final'
+    runtime 'org.cache2k:cache2k-jcache:2.6.1.Final'
 
     testCompile "io.micronaut:micronaut-inject-groovy"
     testCompile "org.grails:grails-gorm-testing-support"
@@ -136,7 +136,7 @@ dependencies {
     }
 
     compile 'au.org.ala:ala-cas-client:3.0.0'
-    compile ("au.org.ala.names:ala-namematching-client:1.7") {
+    compile ('au.org.ala.names:ala-namematching-client:1.9-SNAPSHOT') {
         exclude group: "com.squareup.okhttp3", module: "okhttp"
     }
     compile 'au.org.ala.plugins:openapi:1.1.0'

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -206,6 +206,8 @@ outboundhttp:
 
 namematching:
     serviceURL: https://namematching-ws.ala.org.au
+    defaultLoose: false
+    defaultStyle: STRICT
     dataCacheConfig:
         enableJmx: true
         entryCapacity: 20000

--- a/grails-app/controllers/au/org/ala/specieslist/EditorController.groovy
+++ b/grails-app/controllers/au/org/ala/specieslist/EditorController.groovy
@@ -197,12 +197,12 @@ class EditorController {
                 sli.rawScientificName = params.rawScientificName
                 changed = true
                 // lookup guid
-                helperService.matchNameToSpeciesListItem(sli.rawScientificName, sli)
+                helperService.matchNameToSpeciesListItem(sli.rawScientificName, sli, sli.mylist)
                 //sli.guid = helperService.findAcceptedLsidByScientificName(sli.rawScientificName)?: helperService.findAcceptedLsidByCommonName(sli.rawScientificName)
             }
             if (changed) {
                 log.debug "re-matching name for ${params.rawScientificName}"
-                helperService.matchNameToSpeciesListItem(sli.rawScientificName, sli)
+                helperService.matchNameToSpeciesListItem(sli.rawScientificName, sli, sli.mylist)
             }
 
             if (!sli.validate()) {

--- a/grails-app/controllers/au/org/ala/specieslist/SpeciesListController.groovy
+++ b/grails-app/controllers/au/org/ala/specieslist/SpeciesListController.groovy
@@ -30,6 +30,7 @@ class SpeciesListController {
     private static final String[] ACCEPTED_CONTENT_TYPES = ["text/plain", "text/csv"]
 
     HelperService helperService
+    ColumnMatchingService columnMatchingService
     AuthService authService
     BieService bieService
     BiocacheService biocacheService
@@ -522,7 +523,7 @@ class SpeciesListController {
     private parseDataFromCSV(CSVReader csvReader, String separator) {
         def rawHeader = csvReader.readNext()
         log.debug(rawHeader.toList()?.toString())
-        def parsedHeader = helperService.parseHeader(rawHeader) ?: helperService.parseData(rawHeader)
+        def parsedHeader = columnMatchingService.parseHeader(rawHeader) ?: helperService.parseData(rawHeader)
         def processedHeader = parsedHeader.header
         log.debug(processedHeader?.toString())
         def dataRows = new ArrayList<String[]>()
@@ -531,7 +532,7 @@ class SpeciesListController {
             dataRows.add(helperService.parseRow(currentLine.toList()))
             currentLine = csvReader.readNext()
         }
-        def nameColumns = helperService.speciesNameColumns + helperService.commonNameColumns
+        def nameColumns = columnMatchingService.speciesNameMatcher.names + columnMatchingService.commonNameMatcher.names
         if (processedHeader.find {
             it == "scientific name" || it == "vernacular name" || it == "common name" || it == "ambiguous name"
         } && processedHeader.size() > 0) {

--- a/grails-app/controllers/au/org/ala/specieslist/WebServiceController.groovy
+++ b/grails-app/controllers/au/org/ala/specieslist/WebServiceController.groovy
@@ -282,12 +282,16 @@ class WebServiceController {
                 dataResourceUid: sl.dataResourceUid,
                 listName       : sl.listName,
                 dateCreated    : sl.dateCreated,
+                lastUpdated    : sl.lastUpdated,
+                lastUploaded   : sl.lastUploaded,
                 username       : sl.username,
                 fullName       : sl.getFullName(),
                 itemCount      : sl.itemsCount,//SpeciesListItem.countByList(sl)
                 isAuthoritative: (sl.isAuthoritative ?: false),
                 isInvasive     : (sl.isInvasive ?: false),
-                isThreatened   : (sl.isThreatened ?: false)
+                isThreatened   : (sl.isThreatened ?: false),
+                looseSearch    : sl.looseSearch,
+                searchStyle    : sl.searchStyle?.toString()
             ]
             if (sl.listType) {
                 retValue["listType"] = sl?.listType?.toString()
@@ -313,11 +317,13 @@ class WebServiceController {
             def listCounts = allLists.totalCount
             def retValue = [listCount: listCounts, sort: params.sort, order: params.order, max: params.max, offset: params.offset,
                             lists    : allLists.collect {
-                                [dataResourceUid: it.dataResourceUid,
+                                [
+                                 dataResourceUid: it.dataResourceUid,
                                  listName       : it.listName,
                                  listType       : it?.listType?.toString(),
                                  dateCreated    : it.dateCreated,
                                  lastUpdated    : it.lastUpdated,
+                                 lastUploaded   : it.lastUploaded,
                                  username       : it.username,
                                  fullName       : it.getFullName(),
                                  itemCount      : it.itemsCount,
@@ -328,9 +334,12 @@ class WebServiceController {
                                  sdsType        : it.sdsType,
                                  isAuthoritative: it.isAuthoritative ?: false,
                                  isInvasive     : it.isInvasive ?: false,
-                                 isThreatened   : it.isThreatened ?: false]
-                            }]
+                                 isThreatened   : it.isThreatened ?: false,
+                                 looseSearch    : it.looseSearch,
+                                 searchStyle    : it.searchStyle?.toString()
+                                ]
 
+                            }]
             render retValue as JSON
         }
     }

--- a/grails-app/domain/au/org/ala/specieslist/SpeciesList.groovy
+++ b/grails-app/domain/au/org/ala/specieslist/SpeciesList.groovy
@@ -15,6 +15,8 @@
 
 package au.org.ala.specieslist
 
+import au.org.ala.names.ws.api.SearchStyle
+
 class SpeciesList {
     def authService
 
@@ -29,6 +31,7 @@ class SpeciesList {
     String wkt
     Date dateCreated
     Date lastUpdated
+    Date lastUploaded
     ListType listType
     Boolean isPrivate
     Boolean isSDS
@@ -42,8 +45,9 @@ class SpeciesList {
     String generalisation
     String category
     String sdsType
+    Boolean looseSearch // if undefined use the server default
+    SearchStyle searchStyle // if undefined use the server default
     String ownerFullName // derived by concatenating the firstName and surname fields
-
     static transients = [ "fullName" ]
 
     static hasMany = [items: SpeciesListItem, editors: String]
@@ -67,6 +71,9 @@ class SpeciesList {
         generalisation(nullable: true)
         authority(nullable:  true)
         sdsType nullable:  true
+        looseSearch nullable: true
+        searchStyle nullable: true
+        lastUploaded nullable: true
         userId nullable: true
         ownerFullName nullable: true // derived
     }

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -95,6 +95,9 @@ speciesList.authority.label=SDS Authority
 speciesList.category.label=SDS Category
 speciesList.generalisation.label=SDS Coordinate Generalisation
 speciesList.sdsType.label=SDS Type
+speciesList.looseSearch.label=Loose Name Search
+speciesList.searchStyle.label=Name Search Style
+speciesList.lastUploaded.label=Date last uploaded
 
 upload.heading.hasList=Resubmit to an existing list
 upload.heading=Upload a list

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -370,7 +370,9 @@ public.lists.items.header01=Supplied Name
 public.lists.items.header02=Scientific Name (matched)
 public.lists.items.header03=Author (matched)
 public.lists.items.header04=Common Name (matched)
-public.lists.items.header05=Image
+public.lists.items.header05=Family (matched)
+public.lists.items.header06=Kingdom (matched)
+public.lists.items.header07=Image
 generic.lists.label.reload= - Page will be reloaded ...
 public.lists.items.edit.error=Required field: supplied name cannot be blank
 

--- a/grails-app/services/au/org/ala/specieslist/ColumnMatchingService.groovy
+++ b/grails-app/services/au/org/ala/specieslist/ColumnMatchingService.groovy
@@ -1,0 +1,222 @@
+package au.org.ala.specieslist
+
+import au.org.ala.names.ws.api.NameSearch
+import grails.config.Config
+import grails.core.support.GrailsConfigurationAware
+import org.apache.commons.lang3.StringUtils
+
+
+/**
+ * A service that matches column names from/to KVP values
+ */
+class ColumnMatchingService implements GrailsConfigurationAware {
+    ColumnMatcher speciesNameMatcher = new ColumnMatcher('rawScientificName', 'name')
+    ColumnMatcher authorMatcher = new ColumnMatcher('author', 'author')
+    ColumnMatcher commonNameMatcher = new ColumnMatcher('commonName', 'commonName')
+    ColumnMatcher ambiguousNameMatcher = new ColumnMatcher('ambiguousName', null)
+    ColumnMatcher kingdomMatcher = new ColumnMatcher('kingdom', 'kingdom')
+    ColumnMatcher phylumMatcher = new ColumnMatcher('phylum', 'phylum')
+    ColumnMatcher classMatcher = new ColumnMatcher('class', 'class')
+    ColumnMatcher orderMatcher = new ColumnMatcher('order', 'order')
+    ColumnMatcher familyMatcher = new ColumnMatcher('family', 'family')
+    ColumnMatcher genusMatcher = new ColumnMatcher('genus', 'genus')
+    ColumnMatcher rankMatcher = new ColumnMatcher('rank', 'rank')
+    boolean loose = false
+
+    @Override
+    void setConfiguration(Config configuration) {
+        this.speciesNameMatcher = new ColumnMatcher('rawScientificName', configuration.getProperty("speciesNameColumns"))
+        this.authorMatcher = new ColumnMatcher('author', configuration.getProperty("authorColumns"))
+        this.commonNameMatcher = new ColumnMatcher('commonName', configuration.getProperty("commonNameColumns"))
+        this.ambiguousNameMatcher = new ColumnMatcher('ambiguousName', configuration.getProperty("ambiguousNameColumns"))
+        this.kingdomMatcher = new ColumnMatcher('kingdom', configuration.getProperty("kingdomColumns"))
+        this.phylumMatcher = new ColumnMatcher('phylum', configuration.getProperty("phylumColumns"))
+        this.classMatcher = new ColumnMatcher('class', configuration.getProperty("classColumns"))
+        this.orderMatcher = new ColumnMatcher('order', configuration.getProperty("orderColumns"))
+        this.familyMatcher = new ColumnMatcher('family', configuration.getProperty("familyColumns"))
+        this.genusMatcher = new ColumnMatcher('genus', configuration.getProperty("genusColumns"))
+        this.rankMatcher = new ColumnMatcher('rank', configuration.getProperty("rankColumns"))
+        this.loose = configuration.getProperty("namematching.loose", Boolean.class, false)
+    }
+
+    /**
+     * Build a name search for a species list item.
+     * <p>
+     * The scientific name comes from the raw scientifc name.
+     * All other values come from additional KVP values.
+     * </p>
+     *
+     * @param sli The species list item
+     * @return The name search
+     */
+    NameSearch buildSearch(SpeciesListItem sli) {
+        return NameSearch.builder()
+                .scientificName(sli.rawScientificName)
+                .scientificNameAuthorship(this.authorMatcher.get(sli))
+                .kingdom(this.kingdomMatcher.get(sli))
+                .phylum(this.phylumMatcher.get(sli))
+                .clazz(this.classMatcher.get(sli))
+                .order(this.orderMatcher.get(sli))
+                .family(this.familyMatcher.get(sli))
+                .genus(this.genusMatcher.get(sli))
+                .rank(this.rankMatcher.get(sli))
+                .vernacularName(this.commonNameMatcher.get(sli))
+                .loose(this.loose)
+                .build();
+    }
+
+    /**
+     * determines what the header should be based on the data supplied
+     * @param header
+     */
+    def parseData(String[] header) {
+        def hasName = false
+        def unknowni = 1
+        def headerResponse = header.collect {
+            if (findAcceptedLsidByScientificName(it)) {
+                hasName = true
+                "scientific name"
+            } else if (findAcceptedLsidByCommonName(it)) {
+                hasName = true
+                "vernacular name"
+            } else {
+                "UNKNOWN" + (unknowni++)
+            }
+        }
+        [header: headerResponse, nameFound: hasName]
+    }
+
+    /**
+     * Check find suitable names from a header
+     *
+     * @param header The header
+     * 
+     * @return The results
+     */
+    def parseHeader(String[] header) {
+        //first step check to see if scientificname or common name is provided as a header
+        def hasName = false;
+        def headerResponse = header.collect {
+            def search = canonicalName(it)
+            if (this.speciesNameMatcher.hasName(search)) {
+                hasName = true
+                "scientific name"
+            } else if (this.commonNameMatcher.hasName(search)) {
+                hasName = true
+                "vernacular name"
+            } else if (this.ambiguousNameMatcher.hasName(search)) {
+                hasName = true
+                "ambiguous name"
+            } else {
+                it
+            }
+        }
+
+        headerResponse = parseHeadersCamelCase(headerResponse)
+
+        if (hasName)
+            [header: headerResponse, nameFound: hasName]
+        else
+            null
+    }
+
+    // specieslist-webapp#50
+    protected parseHeadersCamelCase(List header) {
+        def ret = []
+        header.each { String it ->
+            StringBuilder word = new StringBuilder()
+            if (Character.isUpperCase(it.codePointAt(0))) {
+                for (int i = 0; i < it.size(); i++) {
+                    if (Character.isUpperCase(it[i] as char) && i != 0) {
+                        word << " "
+                    }
+                    word << it[i]
+                }
+
+                ret << word.toString()
+            } else {
+                ret << it
+            }
+        }
+        ret
+    }
+
+    int getSpeciesIndex(Object[] header) {
+        int idx = header.findIndexOf { this.speciesNameMatcher.hasName(this.canonicalName(it)) }
+        if (idx < 0)
+            idx = header.findIndexOf { this.ambiguousNameMatcher.hasName(this.canonicalName(it)) }
+        if (idx < 0)
+            idx = header.findIndexOf { this.commonNameMatcher.hasName(this.canonicalName(it)) }
+        return idx
+    }
+
+    /**
+     * Build a map locating various terms in an array for the various columns.
+     *
+     * @param header The header
+     * @return The column-name - column index map
+     */
+    Map getTermAndIndex(Object[] header){
+        Map termMap = new HashMap<String, Integer>();
+        this.speciesNameMatcher.locate(header, termMap)
+        this.commonNameMatcher.locate(header, termMap)
+        this.kingdomMatcher.locate(header, termMap)
+        this.phylumMatcher.locate(header, termMap)
+        this.classMatcher.locate(header, termMap)
+        this.orderMatcher.locate(header, termMap)
+        this.familyMatcher.locate(header, termMap)
+        this.genusMatcher.locate(header, termMap)
+        this.rankMatcher.locate(header, termMap)
+        return termMap
+    }
+
+    protected String canonicalName(String name) {
+        return name.toLowerCase().replaceAll('\\s', '')
+    }
+
+    class ColumnMatcher {
+        String column;
+        String[] names
+        Set<String> matches
+        
+        ColumnMatcher(String column, String names) {
+            this.column = column;
+            this.names = names?.split(',') ?: []
+            this.matches = this.names.inject([], { v, s -> v.add(canonicalName(s)); v}) as Set
+        }
+
+        /**
+         * Get a KVP value from an item, based on possible column names.
+         *
+         * @param sli The species list item
+         * @return The first matching value, or null for not found
+         */
+        String get(SpeciesListItem sli) {
+            for (String name : this.names) {
+                SpeciesListKVP kvp = sli.kvpValues.find { it.key == name }
+                String value = kvp ? StringUtils.trimToNull(kvp.value) : null
+                if (value)
+                    return value
+            }
+            return null
+        }
+
+        /**
+         * See if we have a specific name.
+         * @param name A pre-canonicalised name
+         * @return True if this matches
+         */
+        boolean hasName(String name) {
+            name = canonicalName(name)
+            return this.matches.contains(name)
+        }
+
+        int locate(Object[] header, Map map) {
+            int idx = header.findIndexOf { hasName(it.toString()) }
+            if (idx != -1) {
+                map.put(this.column, idx)
+            }
+            return idx
+        }
+    }
+}

--- a/grails-app/services/au/org/ala/specieslist/NameExplorerService.groovy
+++ b/grails-app/services/au/org/ala/specieslist/NameExplorerService.groovy
@@ -32,17 +32,17 @@ import org.apache.commons.lang.StringUtils
 class NameExplorerService implements GrailsConfigurationAware {
     private NameMatchService alaNameUsageMatchServiceClient
 
-    def grailsApplication
+    ColumnMatchingService columnMatchingService
 
     @Override
     void setConfiguration(Config config) {
         DataCacheConfiguration dataCacheConfig = DataCacheConfiguration.builder()
-                .entryCapacity(grailsApplication.config.getProperty("namematching.dataCacheConfig.entryCapacity", Integer, 20000))
-                .enableJmx(grailsApplication.config.getProperty("namematching.dataCacheConfig.enableJmx", Boolean, false))
-                .eternal(grailsApplication.config.getProperty("namematching.dataCacheConfig.eternal", Boolean, false))
-                .keepDataAfterExpired(grailsApplication.config.getProperty("namematching.dataCacheConfig.keepDataAfterExpired", Boolean, false))
-                .permitNullValues(grailsApplication.config.getProperty("namematching.dataCacheConfig.permitNullValues", Boolean, false))
-                .suppressExceptions(grailsApplication.config.getProperty("namematching.dataCacheConfig.suppressExceptions", Boolean, false))
+                .entryCapacity(config.getProperty("namematching.dataCacheConfig.entryCapacity", Integer, 20000))
+                .enableJmx(config.getProperty("namematching.dataCacheConfig.enableJmx", Boolean, false))
+                .eternal(config.getProperty("namematching.dataCacheConfig.eternal", Boolean, false))
+                .keepDataAfterExpired(config.getProperty("namematching.dataCacheConfig.keepDataAfterExpired", Boolean, false))
+                .permitNullValues(config.getProperty("namematching.dataCacheConfig.permitNullValues", Boolean, false))
+                .suppressExceptions(config.getProperty("namematching.dataCacheConfig.suppressExceptions", Boolean, false))
                 .build()
 
         URL service = new URL(config.getProperty("namematching.serviceURL"))
@@ -55,11 +55,11 @@ class NameExplorerService implements GrailsConfigurationAware {
 
     /**
      * Find a NameUsageMatch by a NameSearch
-     * @param search NameUsageMatch
+     * @param sli The species list item
      * @return NameSearch
      */
-    NameUsageMatch find(NameSearch search) {
-        return alaNameUsageMatchServiceClient.match(search)
+    NameUsageMatch find(SpeciesListItem sli) {
+        return alaNameUsageMatchServiceClient.match(columnMatchingService.buildSearch(sli))
     }
 
     /**
@@ -68,10 +68,7 @@ class NameExplorerService implements GrailsConfigurationAware {
      * @return list of NameUsageMatch, <b>in the same order as the items passed in</b>
      */
     List<NameUsageMatch> findAll(List<SpeciesListItem> items){
-        List<NameSearch> searches = new ArrayList<>();
-        items.eachWithIndex { SpeciesListItem item, Integer i ->
-            searches.add(i, buildNameSearch(item))
-        }
+        List<NameSearch> searches = items.collect { sli -> columnMatchingService.buildSearch(sli)}
         return alaNameUsageMatchServiceClient.matchAll(searches)
     }
 
@@ -94,7 +91,7 @@ class NameExplorerService implements GrailsConfigurationAware {
         NameSearch.NameSearchBuilder builder = new NameSearch.NameSearchBuilder()
 
         builder.scientificName = StringUtils.trimToNull(scientificName)
-        NameUsageMatch result = find(builder.build())
+        NameUsageMatch result = alaNameUsageMatchServiceClient.match(builder.build())
         return result.success? result.taxonConceptID : null
     }
 
@@ -119,7 +116,7 @@ class NameExplorerService implements GrailsConfigurationAware {
 
         builder.scientificName = StringUtils.trimToNull(scientificName)
         builder.family = StringUtils.trimToNull(family)
-        NameUsageMatch result = find(builder.build())
+        NameUsageMatch result = alaNameUsageMatchServiceClient.match(builder.build())
         return result.success? result : null
     }
 
@@ -132,7 +129,7 @@ class NameExplorerService implements GrailsConfigurationAware {
         NameSearch.NameSearchBuilder builder = new NameSearch.NameSearchBuilder()
 
         builder.scientificName = StringUtils.trimToNull(scientificName)
-        NameUsageMatch result = find(builder.build())
+        NameUsageMatch result = alaNameUsageMatchServiceClient.match(builder.build())
         return result.success? result : null
     }
 
@@ -145,7 +142,7 @@ class NameExplorerService implements GrailsConfigurationAware {
         NameSearch.NameSearchBuilder builder = new NameSearch.NameSearchBuilder()
 
         builder.vernacularName = StringUtils.trimToNull(commonName)
-        NameUsageMatch result = find(builder.build())
+        NameUsageMatch result = alaNameUsageMatchServiceClient.match(builder.build())
         return result.success? result : null
     }
 
@@ -200,24 +197,8 @@ class NameExplorerService implements GrailsConfigurationAware {
         if (rank) {
             builder.rank = StringUtils.trimToNull(rank)
         }
-        NameUsageMatch result = find(builder.build())
+        NameUsageMatch result = alaNameUsageMatchServiceClient.match(builder.build())
         return result.success? result : null
     }
 
-    private NameSearch buildNameSearch(SpeciesListItem sli){
-        NameSearch.NameSearchBuilder builder = new NameSearch.NameSearchBuilder()
-        if (sli.rawScientificName) {
-            builder.scientificName = StringUtils.trimToNull(sli.rawScientificName)
-        }
-        if (sli.commonName) {
-            builder.vernacularName = StringUtils.trimToNull(sli.commonName)
-        }
-        if (sli.kingdom) {
-            builder.kingdom = StringUtils.trimToNull(sli.kingdom)
-        }
-        if (sli.family) {
-            builder.family = StringUtils.trimToNull(sli.family)
-        }
-        return builder.loose(true).build()
-    }
-}
+ }

--- a/grails-app/services/au/org/ala/specieslist/NameExplorerService.groovy
+++ b/grails-app/services/au/org/ala/specieslist/NameExplorerService.groovy
@@ -56,19 +56,21 @@ class NameExplorerService implements GrailsConfigurationAware {
     /**
      * Find a NameUsageMatch by a NameSearch
      * @param sli The species list item
+     * @param sl The parent species list (which may not yet be linked to the item)
      * @return NameSearch
      */
-    NameUsageMatch find(SpeciesListItem sli) {
-        return alaNameUsageMatchServiceClient.match(columnMatchingService.buildSearch(sli))
+    NameUsageMatch find(SpeciesListItem sli, SpeciesList sl) {
+        return alaNameUsageMatchServiceClient.match(columnMatchingService.buildSearch(sli, sl))
     }
 
     /**
      * Find NameUsageMatch for given list items
      * @param items list of SpeciesListItem
+     * @param sl The parent species list (which may not yet be linked to the item)
      * @return list of NameUsageMatch, <b>in the same order as the items passed in</b>
      */
-    List<NameUsageMatch> findAll(List<SpeciesListItem> items){
-        List<NameSearch> searches = items.collect { sli -> columnMatchingService.buildSearch(sli)}
+    List<NameUsageMatch> findAll(List<SpeciesListItem> items, SpeciesList sl){
+        List<NameSearch> searches = items.collect { sli -> columnMatchingService.buildSearch(sli, sl)}
         return alaNameUsageMatchServiceClient.matchAll(searches)
     }
 

--- a/grails-app/views/speciesList/upload.gsp
+++ b/grails-app/views/speciesList/upload.gsp
@@ -1,3 +1,4 @@
+<%@ page import="au.org.ala.names.ws.api.SearchStyle" %>
 %{--
   - Copyright (C) 2012 Atlas of Living Australia
   - All Rights Reserved.
@@ -181,6 +182,8 @@
                     map['sdsType'] = $('#sdsType').val();
                 }
             }
+            map['looseSearch'] = $('#looseSearch').val();
+            map['searchStyle'] = $('#searchStyle').val();
             //console.log("The map: ",map);
             $('#recognisedDataDiv').hide();
             $('#uploadDiv').hide();
@@ -442,7 +445,18 @@
                             <td>
                                 <g:textArea cols="100" rows="5" class="full-width" name="listWkt">${list?.wkt}</g:textArea>
                             </td>
-
+                        </tr>
+                        <tr>
+                            <td><label for="looseSearch">${message(code:'speciesList.looseSearch.label', default:'Loose Search')}</label></td>
+                            <td>
+                                <g:select noSelection="${['':'--']}" from="[true, false]" name="looseSearch" style="width:99%" value="${list?.looseSearch}" />
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><label for="searchStyle">${message(code:'speciesList.searchStyle.label', default:'Search Style')}</label></td>
+                            <td>
+                                <g:select name="searchStyle" noSelection="${['':'--']}" from="${SearchStyle.values()}" style="width:99%" value="${list?.searchStyle}" />
+                            </td>
                         </tr>
                         </tbody>
                     </table>

--- a/grails-app/views/speciesListItem/list.gsp
+++ b/grails-app/views/speciesListItem/list.gsp
@@ -905,10 +905,14 @@
                                                   params="${[fq: fqs]}"></g:sortableColumn>
                                 <g:sortableColumn property="matchedName" title="${message(code:'public.lists.items.header02', default:'Scientific Name (matched)')}"
                                                   params="${[fq: fqs]}"></g:sortableColumn>
-                                <th>${message(code:'public.lists.items.header05', default:'Image')}</th>
+                                <th>${message(code:'public.lists.items.header07', default:'Image')}</th>
                                 <g:sortableColumn property="author" title="${message(code:'public.lists.items.header03', default:'Author (matched)')}"
                                                   params="${[fq: fqs]}"></g:sortableColumn>
                                 <g:sortableColumn property="commonName" title="${message(code:'public.lists.items.header04', default:'Common Name (matched)')}"
+                                                  params="${[fq: fqs]}"></g:sortableColumn>
+                                <g:sortableColumn property="family" title="${message(code:'public.lists.items.header05', default:'Family (matched)')}"
+                                                  params="${[fq: fqs]}"></g:sortableColumn>
+                                <g:sortableColumn property="kingdom" title="${message(code:'public.lists.items.header06', default:'Kingdom (matched)')}"
                                                   params="${[fq: fqs]}"></g:sortableColumn>
                                 <g:each in="${keys}" var="key">
                                     <th>${key}</th>
@@ -964,6 +968,8 @@
                                     </td>
                                     <td>${result.author}</td>
                                     <td id="cn_${result.guid}">${result.commonName}</td>
+                                    <td id="fm_${result.guid}">${result.family}</td>
+                                    <td id="kn_${result.guid}">${result.kingdom}</td>
                                     <g:each in="${keys}" var="key">
                                         <g:set var="kvp" value="${result.kvpValues.find { it.key == key }}"/>
                                         <g:set var="val" value="${kvp?.vocabValue ?: kvp?.value}"/>

--- a/grails-app/views/speciesListItem/list.gsp
+++ b/grails-app/views/speciesListItem/list.gsp
@@ -479,10 +479,13 @@
             </g:if>
             <dt>${message(code: 'speciesList.dateCreated.label', default: 'Date submitted')}</dt>
             <dd><g:formatDate format="yyyy-MM-dd"
-                              date="${speciesList.dateCreated ?: 0}"/><!-- ${speciesList.lastUpdated} --></dd>
+                              date="${speciesList.dateCreated}"/><!-- ${speciesList.lastUpdated} --></dd>
             <dt>${message(code: 'speciesList.lastUpdated.label', default: 'Date updated')}</dt>
             <dd><g:formatDate format="yyyy-MM-dd"
-                              date="${speciesList.lastUpdated ?: 0}"/></dd>
+                              date="${speciesList.lastUpdated}"/></dd>
+            <dt>${message(code: 'speciesList.lastUploaded.label', default: 'Date last loaded')}</dt>
+            <dd><g:formatDate format="yyyy-MM-dd"
+                              date="${speciesList.lastUploaded}"/></dd>
             <dt>${message(code: 'speciesList.isPrivate.label', default: 'Is private')}</dt>
             <dd><g:formatBoolean boolean="${speciesList.isPrivate ?: false}" true="Yes" false="No"/></dd>
             <dt>${message(code: 'speciesList.isBIE.label', default: 'Included in BIE')}</dt>
@@ -519,6 +522,10 @@
                 <dt>${message(code: 'speciesList.editors.label', default: 'List editors')}</dt>
                 <dd>${speciesList.editors.collect { sl.getFullNameForUserId(userId: it) }?.join(", ")}</dd>
             </g:if>
+            <dt>${message(code: 'speciesList.looseSearch.label', default: 'Loose search')}</dt>
+            <dd><g:formatBoolean boolean="${speciesList.looseSearch}" true="Yes" false="No"/></dd>
+            <dt>${message(code: 'speciesList.searchStyle.label', default: 'Search style')}</dt>
+            <dd>${speciesList.searchStyle}</dd>
             <dt>${message(code: 'speciesList.metadata.label', default: 'Metadata link')}</dt>
             <dd><a href="${grailsApplication.config.collectory.baseURL}/public/show/${speciesList.dataResourceUid}">${grailsApplication.config.collectory.baseURL}/public/show/${speciesList.dataResourceUid}</a>
             </dd>
@@ -716,6 +723,18 @@
                             </div>
                         </g:if>
                     </g:if>
+                    <div class="form-group">
+                        <label class="control-label col-md-2" for="looseSearch">${message(code:'speciesList.looseSearch.label', default:'Loose Search')}</label>
+                        <div class="col-md-10">
+                            <g:select noSelection="${['':'--']}" from="[true, false]" name="looseSearch" style="width:99%" value="${speciesList.looseSearch}" />
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="control-label col-md-2" for="searchStyle">${message(code:'speciesList.searchStyle.label', default:'Search Style')}</label>
+                        <div class="col-md-10">
+                            <g:select name="searchStyle" noSelection="${['':'--']}" from="${au.org.ala.names.ws.api.SearchStyle.values()}" style="width:99%" value="${speciesList.searchStyle}" />
+                        </div>
+                    </div>
                     <div class="form-group">
                         <div class="col-md-offset-2 col-md-10">
                             <button type="submit" id="edit-meta-submit" class="btn btn-primary">${message(code:'generic.lists.button.save.label', default:'Save')}</button>

--- a/src/test/groovy/au/org/ala/specieslist/controller/SpeciesListControllerSpec.groovy
+++ b/src/test/groovy/au/org/ala/specieslist/controller/SpeciesListControllerSpec.groovy
@@ -15,6 +15,7 @@
 
 package au.org.ala.specieslist.controller
 
+import au.org.ala.specieslist.ColumnMatchingService
 import au.org.ala.specieslist.HelperService
 import au.org.ala.specieslist.SpeciesListController
 import grails.testing.gorm.DataTest
@@ -36,6 +37,7 @@ class SpeciesListControllerSpec extends Specification implements ControllerUnitT
     def setup() {
         mockMultipartRequest.getFile(_) >> mockFile
         controller.helperService = new HelperService()
+        controller.columnMatchingService = new ColumnMatchingService()
 //        controller.helperService.transactionManager = transactionManager
     }
 

--- a/src/test/groovy/au/org/ala/specieslist/service/ColumnMatchingServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/specieslist/service/ColumnMatchingServiceSpec.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 Atlas of Living Australia
+ * All Rights Reserved.
+ *
+ * The contents of this file are subject to the Mozilla Public
+ * License Version 1.1 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ */
+
+package au.org.ala.specieslist.service
+
+import au.org.ala.names.ws.api.NameUsageMatch
+import au.org.ala.specieslist.*
+import au.org.ala.web.AuthService
+import com.opencsv.CSVReader
+import grails.testing.gorm.DataTest
+import grails.testing.services.ServiceUnitTest
+import org.grails.web.json.JSONObject
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class ColumnMatchingServiceSpec extends Specification implements ServiceUnitTest<ColumnMatchingService>, DataTest {
+
+    def columnMatchingService = new ColumnMatchingService()
+
+    void setupSpec() {
+        mockDomains(SpeciesListItem, SpeciesList, SpeciesListKVP)
+    }
+
+    def setup() {
+        grailsApplication.config.commonNameColumns="commonname,vernacularname"
+        grailsApplication.config.ambiguousNameColumns="name"
+        grailsApplication.config.speciesNameColumns = "scientificname,suppliedname,taxonname,species"
+        columnMatchingService.setConfiguration(grailsApplication.config)
+    }
+
+
+    def "camel case column names should be split by spaces before each uppercase character"() {
+        when:
+        def result = columnMatchingService.parseHeader(
+                ["species", "AnyReallyLongCamelCaseHeaderName", "ÖsterreichName", "conservationCode"] as String[])
+
+        then:
+        assert result?.header?.contains("scientific name")
+        assert result?.header?.contains("Any Really Long Camel Case Header Name")
+        assert result?.header?.contains("Österreich Name");
+        assert result?.header?.contains("conservationCode")
+    }
+
+}


### PR DESCRIPTION
Fix for issue #235 in conjunction with upgrades to namematching-service (1.9-SNAPSHOT)

Matching behaviour is per-list configurable.
Also include lastUploaded date to allow tracking of changes to the list data (bulk loads only)