### PR TITLE
issue #257 updating visibleLists query from c.get to c.list as expect…

### DIFF
--- a/grails-app/services/au/org/ala/specieslist/QueryService.groovy
+++ b/grails-app/services/au/org/ala/specieslist/QueryService.groovy
@@ -277,9 +277,9 @@ class QueryService {
      */
     def visibleLists(boolean includePublicLists, boolean hidePrivateLists) {
         def c = SpeciesList.createCriteria()
-        def lists = c.get {
+        def lists = c.list {
             projections {
-                DATA_RESOURCE_UID
+                property(DATA_RESOURCE_UID)
             }
             or {
                 if (includePublicLists) {


### PR DESCRIPTION
…ed result is more than one, updating the projections section to specify the actual projection to retun i.e. 'property' to return a list of dataResoureceUid's

Fix for #257 