### PR TITLE
Apply 

### DIFF
--- a/grails-app/controllers/au/org/ala/specieslist/SpeciesListController.groovy
+++ b/grails-app/controllers/au/org/ala/specieslist/SpeciesListController.groovy
@@ -449,11 +449,12 @@ class SpeciesListController {
      */
     def occurrences(){
         def splist = SpeciesList.findByDataResourceUid(params.id)
+        def title = "Species List: " + splist.listName
         if (biocacheService.isListIndexed(params.id)) {
             if (splist.wkt && !splist.wkt.isEmpty()) {
-                redirect(url: biocacheService.getQueryUrlForListWithinPolygon(params.id, splist.wkt))
+                redirect(url: biocacheService.performSearchForSpeciesListWithWkt(params.id, title, splist.wkt))
             } else {
-                redirect(url: biocacheService.getQueryUrlForListWithinPolygon(params.id))
+                redirect(url: biocacheService.getQueryUrlForList(params.id))
             }
         } else if (params.id && params.type){
             if (splist && !isViewable(splist)) {
@@ -463,7 +464,6 @@ class SpeciesListController {
 
             def guids = getGuidsForList(params.id, grailsApplication.config.downloadLimit)
             def unMatchedNames = getUnmatchedNamesForList(params.id, grailsApplication.config.downloadLimit)
-            def title = "Species List: " + splist.listName
             def downloadDto = new DownloadDto()
             bindData(downloadDto, params)
 

--- a/grails-app/services/au/org/ala/specieslist/BiocacheService.groovy
+++ b/grails-app/services/au/org/ala/specieslist/BiocacheService.groovy
@@ -70,6 +70,47 @@ class BiocacheService {
         }
     }
 
+    def getSpeciesListWithWktQid(speciesListId, title, wkt){
+        def http = new HTTPBuilder(grailsApplication.config.biocacheService.baseURL +"/webportal/params")
+        // check apiGateway.enabled since "/webportal/params" is deprecated and replaced with generated "qio" (protected in APi Gateway)
+        if(grailsApplication.config.getProperty("apiGateway.enabled", Boolean, false)){
+            http = new HTTPBuilder(grailsApplication.config.biocacheService.baseURL +"/qid")
+            // /qid POST is protected on API Gateway - generate and include a JWT in the request
+            http.setHeaders([Authorization: "Bearer ${webService.getTokenService().getAuthToken(false)}"])
+        }
+
+        http.getClient().getParams().setParameter("http.socket.timeout", getTimeout())
+        def query = ""
+
+        if (speciesListId) {
+            query = "species_list_uid:" + speciesListId
+        }
+
+        def postBody = [q:query, wkt: wkt, title: title]
+        log.debug "postBody = " + postBody
+
+        try {
+            http.post(body: postBody, requestContentType:groovyx.net.http.ContentType.URLENC){ resp, reader ->
+                //return the location in the header
+                log.debug(resp.headers?.toString())
+                if (resp.status == 302) {
+                    log.debug "302 redirect response from biocache"
+                    return [status:resp.status, result:resp.headers['location'].getValue()]
+                } else if (resp.status == 200) {
+                    log.debug "200 OK response from biocache"
+                    return [status:resp.status, result:reader.getText()]
+                } else {
+                    log.warn "$resp.status returned from biocache service"
+
+                    return [status:500]
+                }
+            }
+        } catch(ex) {
+            log.error("Error while creating Qid for species list " + speciesListId + "with wkt: " , ex)
+            return null;
+        }
+    }
+
     def getTimeout() {
         int timeout = DEFAULT_TIMEOUT_MILLIS
         def timeoutFromConfig = grailsApplication.config.httpTimeoutMillis
@@ -142,6 +183,20 @@ class BiocacheService {
                     returnUrl = grailsApplication.config.biocache.baseURL + "/download/options1/?searchParams=?q=qid:" + qid + "&targetUri=/occurrences/search&downloadType=records"
                     break
             }
+            returnUrl
+        } else {
+            null
+        }
+    }
+
+    def performSearchForSpeciesListWithWkt(speciesListId, speciesListTitle, wkt) {
+        def response = getSpeciesListWithWktQid(speciesListId, speciesListTitle, wkt)
+        if(response?.status == 302){
+            response.result
+        } else if (response?.status == 200) {
+            log.debug "200 OK response"
+            def qid = response.result
+            def returnUrl = grailsApplication.config.biocache.baseURL + "/occurrences/search?q=qid:" + qid
             returnUrl
         } else {
             null


### PR DESCRIPTION
Hi ALA team, 

Please consider this PR.

 - when fetching occurrences for a species list, also apply its wkt filter (only if wkt is defined for this species list)
 - use Qid api to store wkt parameter (as the string can get extremely long and cause errors ca maximum allowed URL length)