### PR TITLE
#330 Migration changes

### DIFF
--- a/grails-app/conf/application.groovy
+++ b/grails-app/conf/application.groovy
@@ -44,7 +44,6 @@ bieApiKey = "xxxxxx"
 /*** Config specific for species list ***/
 updateUserDetailsOnStartup = false
 iconicSpecies.uid = "dr781"
-api.hidePrivateLists = true
 
 skin.orgNameLong = "Atlas of Living Australia"
 skin.layout = "main"

--- a/grails-app/controllers/au/org/ala/specieslist/SpeciesListItemInterceptor.groovy
+++ b/grails-app/controllers/au/org/ala/specieslist/SpeciesListItemInterceptor.groovy
@@ -37,11 +37,8 @@ class SpeciesListItemInterceptor {
     // gets the 'real' injected services unless we pass them in
     private boolean checkSecurity(String druid, AuthService authService, LocalAuthService localAuthService) {
         SecurityUtil securityUtil = new SecurityUtil(localAuthService: localAuthService, authService: authService)
-        def hidePrivateLists = grailsApplication.config.getProperty('api.hidePrivateLists', Boolean, true)
-        def path = request.forwardURI ?: request.requestURI
-        Boolean isApiCall = path.startsWith('/ws/') || path.startsWith('/speciesListItem/ws/') || path.startsWith('/speciesListItem/downloadList/')
 
-        if (!securityUtil.checkViewAccess(druid, request, response) && (!isApiCall || hidePrivateLists)) {
+        if (!securityUtil.checkViewAccess(druid, request, response)) {
             response.sendError(HttpStatus.SC_UNAUTHORIZED, "Not authorised")
             false
         } else {

--- a/grails-app/controllers/au/org/ala/specieslist/UrlMappings.groovy
+++ b/grails-app/controllers/au/org/ala/specieslist/UrlMappings.groovy
@@ -45,6 +45,8 @@ class UrlMappings {
             action = [GET:'getListDetailsInternal']
         }
 
+        "/ws/speciesListInternal/download/$druid" (controller: 'webService', action:  'downloadListInternal')
+
         "/ws/createItem" (controller: 'webService', action: 'createItem')
 
         "/ws/deleteItem" (controller: 'webService', action: 'deleteItem')

--- a/grails-app/controllers/au/org/ala/specieslist/WebServiceController.groovy
+++ b/grails-app/controllers/au/org/ala/specieslist/WebServiceController.groovy
@@ -323,8 +323,7 @@ class WebServiceController {
             //AC 20141218: Previous behaviour was ignoring custom filter code in queryService.getFilterListResult when params.user
             //parameter was present and params.sort was absent. Moved special case sorting when params.user is present
             //and params.sort is absent into queryService.getFilterListResults so the custom filter code will always be applied.
-            def hidePrivateLists = grailsApplication.config.getProperty('api.hidePrivateLists', Boolean, true)
-            def allLists = queryService.getFilterListResult(params, hidePrivateLists, null, request, response, true)
+            def allLists = queryService.getFilterListResult(params, false, null, request, response, true)
             def listCounts = allLists.totalCount
             def retValue = [listCount: listCounts, sort: params.sort, order: params.order, max: params.max, offset: params.offset,
                             lists    : allLists.collect {

--- a/grails-app/services/au/org/ala/specieslist/QueryService.groovy
+++ b/grails-app/services/au/org/ala/specieslist/QueryService.groovy
@@ -76,7 +76,7 @@ class QueryService {
      *
      * @param params
      */
-    def getFilterListResult(params, boolean hidePrivateLists, List itemIds, request, response, boolean isApiCall = false) {
+    def getFilterListResult(params, boolean hidePrivateLists, List itemIds, request, response) {
         //list should be based on the user that is logged in
         params.max = Math.min(params.max ? params.int('max') : 25, 1000)
 
@@ -159,8 +159,8 @@ class QueryService {
                     } else {
                         log.debug("User is admin, so has visibility of private lists")
                     }
-                } else if (!isApiCall || hidePrivateLists) {
-                    // if there is no user, hidePrivateLists is true and its not an API call, do no show any private records
+                } else {
+                    // if there is no user, do no show any private records
                     or {
                         isNull(IS_PRIVATE)
                         eq(IS_PRIVATE, false)

--- a/grails-app/services/au/org/ala/specieslist/QueryService.groovy
+++ b/grails-app/services/au/org/ala/specieslist/QueryService.groovy
@@ -76,7 +76,7 @@ class QueryService {
      *
      * @param params
      */
-    def getFilterListResult(params, boolean hidePrivateLists, List itemIds, request, response) {
+    def getFilterListResult(params, boolean hidePrivateLists, List itemIds, request, response, boolean internalPrivate = false) {
         //list should be based on the user that is logged in
         params.max = Math.min(params.max ? params.int('max') : 25, 1000)
 
@@ -159,8 +159,8 @@ class QueryService {
                     } else {
                         log.debug("User is admin, so has visibility of private lists")
                     }
-                } else {
-                    // if there is no user, do no show any private records
+                } else if (!internalPrivate) {
+                    // if there is no user, and the request isn't internal & private, do no show any private records
                     or {
                         isNull(IS_PRIVATE)
                         eq(IS_PRIVATE, false)


### PR DESCRIPTION
**Summary of changes**
- Reverted previous commit changes that added list querying feature flag (6e58be2c16c3d89e2edef5982658b89fe51cbedf)
- Added new `/ws/speciesListInternal/download/{druid}` endpoint to enable downloading of lists via M2M JWT
- Add `includePrivate` flag to `/ws/speciesListInternal` querying to enable querying private lists with a M2M JWT

Tested & working locally with new lists migration